### PR TITLE
removed tolocaltimestring and replaced with manual time formatting

### DIFF
--- a/widget-src/components/ChangeLogList.tsx
+++ b/widget-src/components/ChangeLogList.tsx
@@ -2,7 +2,7 @@ import { PADDING } from '../utilities/Styles';
 import { ChangeLogRow } from './ChangeLogRow';
 
 const { widget, currentUser } = figma;
-const { AutoLayout } = widget;
+const { AutoLayout, useEffect } = widget;
 
 interface ChangeLogListProps {
   changeLogIds: string[];
@@ -13,6 +13,10 @@ interface ChangeLogListProps {
 }
 
 export const ChangeLogList = (props: ChangeLogListProps) => {
+  useEffect(() => {
+    console.log('ChangeLogs', props.changeLogs.entries());
+  });
+
   return (
     <AutoLayout
       name="ChangeLog"
@@ -28,16 +32,11 @@ export const ChangeLogList = (props: ChangeLogListProps) => {
         const changeLog = props.changeLogs.get(changeLogId) as ChangeLog;
 
         function isEditable(): boolean {
-          return true;
           // if widget admin
-          if (props.adminId === currentUser?.id) {
-            return true;
-          }
+          // if (props.adminId === currentUser?.id) { return true; }
           // if changeLog owner
-          if (changeLog?.user?.id === currentUser?.id) {
-            return true;
-          }
-          return false;
+          // if (changeLog?.user?.id === currentUser?.id) { return true; }
+          return true;
         }
 
         return (

--- a/widget-src/components/ChangeLogRow.tsx
+++ b/widget-src/components/ChangeLogRow.tsx
@@ -6,7 +6,7 @@ import { formatDate } from '../utilities/Utils';
 import { COLOR, FONT, GAP, PADDING, SPACE } from '../utilities/Styles';
 
 const { widget } = figma;
-const { AutoLayout, Input, Rectangle, Text, useEffect } = widget;
+const { AutoLayout, Input, Rectangle, Text } = widget;
 
 interface ChangeLogRowProps {
   changeLogId: string;
@@ -69,9 +69,10 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
             </Text>
 
             <DateRange
-              editedTime={formatDate(props.changeLog.editedDate, 'datetime')}
-              time={formatDate(props.changeLog.createdDate, 'time')}
+              editedDate={formatDate(props.changeLog.editedDate, 'date')}
+              editedTime={formatDate(props.changeLog.editedDate, 'time')}
               date={formatDate(props.changeLog.createdDate, 'date')}
+              time={formatDate(props.changeLog.createdDate, 'time')}
               editCount={props.changeLog.editCount}
               edited={false}
             />

--- a/widget-src/components/log/DateRange.tsx
+++ b/widget-src/components/log/DateRange.tsx
@@ -1,9 +1,10 @@
 import { COLOR, FONT, GAP } from '../../utilities/Styles';
 
 const { widget } = figma;
-const { AutoLayout, Span, Text } = widget;
+const { AutoLayout, Text } = widget;
 
 interface DateRangeProps {
+  editedDate: string;
   editedTime: string;
   date: string;
   time: string;
@@ -25,21 +26,8 @@ export const DateRange = (props: DateRangeProps) => {
         textCase="upper"
         hidden={props.date === undefined}
       >
-        {props.date}
+        {`${props.date} @ ${props.time}`}
       </Text>
-      {/* <Text
-        name="Time"
-        fill={COLOR.greyDark}
-        lineHeight={FONT.lineHeight.sm}
-        fontFamily={FONT.family}
-        fontSize={FONT.size.sm}
-        letterSpacing={FONT.letterSpacing.sm}
-        fontWeight={FONT.weight.regular}
-        textCase="upper"
-        hidden={props.time === undefined}
-      >
-        {props.time}
-      </Text> */}
 
       {props.editCount >= 2 && (
         <Text
@@ -50,7 +38,7 @@ export const DateRange = (props: DateRangeProps) => {
           fontSize={FONT.size.xs}
           letterSpacing={FONT.letterSpacing.sm}
         >
-          {`(Edited ${props.editedTime})`}
+          {`EDITED ${props.editedDate} @ ${props.editedTime}`}
         </Text>
       )}
     </AutoLayout>

--- a/widget-src/utilities/Utils.ts
+++ b/widget-src/utilities/Utils.ts
@@ -3,48 +3,60 @@
 // returns a random id, generally used as id for a changelog entry
 export const randomId = () => Math.random().toString(36).substring(2, 15);
 
-// accepts an epoch timestamp and a date, time, or datetime formatting type
-// date - returns the provided epoch timestamp in the format of MM/DD/YYYY
-// time - returns the provided epoch timestamp in the format of 00:00:00 AM/PM
-// datetime - returns the provided epoch timestamp in the format of MM/DD/YYYY @ 00:00:00 AM/PM
+// accepts an epoch timestamp and a format ('date', 'time', or 'datetime')
 export const formatDate = (epoch: number, format: 'date' | 'time' | 'datetime') => {
+  const date: Date = new Date(epoch);
   let formattedDate: string = '';
+  let month: number | string = 0;
+  let year: number | string = 0;
+  let yearFull: number | string = 0;
+  let day: number | string = 0;
+  let hours: number | string = 0;
+  let minutes: number | string = 0;
+  let seconds: number | string = 0;
+  let ampm: string = '';
 
+  // if the format includes "date" get date data
+  if (format.includes('date')) {
+    month = date.getMonth() + 1;
+    yearFull = date.getFullYear();
+    year = yearFull.toString().slice(-2);
+    day = date.getDate();
+  }
+  // if the format includes "time" get time data
+  if (format.includes('time')) {
+    hours = date.getHours();
+    minutes = date.getMinutes();
+    seconds = date.getSeconds();
+    // 12 hour clock with am or pm
+    ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12;
+    // the hour '0' should be '12'
+    hours = hours ? hours : 12;
+    // include leading '0' when less than 10
+    minutes = minutes < 10 ? '0' + minutes : minutes;
+    seconds = seconds < 10 ? '0' + seconds : seconds;
+  }
+  // based on format option, return the formatted date
   switch (format) {
     case 'date':
-      const dateDate = new Date(epoch);
-      const monthDate = dateDate.getMonth() + 1;
-      const yearDate = dateDate.getFullYear();
-      const dayDate = dateDate.getDate();
-      formattedDate = `${monthDate}|${dayDate}|${yearDate}`;
+      // MM/DD/YY
+      formattedDate = `${month}|${day}|${year}`;
       break;
 
     case 'time':
-      const dateTime = new Date(epoch);
-      formattedDate = dateTime.toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: true,
-      });
+      // 00:00 AM/PM
+      formattedDate = `${hours}:${minutes} ${ampm}`;
       break;
 
     case 'datetime':
-      const dateobj = new Date(epoch);
-      const monthDateTime = dateobj.getMonth() + 1;
-      const yearDateTime = dateobj.getFullYear();
-      const dayDateTime = dateobj.getDate();
-      const timeDateTime = dateobj.toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: true,
-      });
-      formattedDate = `${monthDateTime}|${dayDateTime}|${yearDateTime} @ ${timeDateTime}`;
+      // MM/DD/YYYY @ 00:00:00 AM/PM
+      formattedDate = `${month}|${day}|${yearFull} @ ${hours}:${minutes}:${seconds} ${ampm}`;
       break;
 
     default:
-      formattedDate = '';
+      // returns error string
+      formattedDate = 'incorrect format';
       break;
   }
 


### PR DESCRIPTION
Using `tolocaltimestring` was returning weird results at 11 and 12 AM/PM, displaying as -1:00 and 0:00 respectively. This solution is more reliable for some reason.