### PR TITLE
Convert to Property Spreading 

### DIFF
--- a/widget-src/components/Button.tsx
+++ b/widget-src/components/Button.tsx
@@ -11,9 +11,13 @@ interface ButtonProps {
   action: () => void;
 }
 
-export const Button = (props: ButtonProps) => {
+export const Button = ({
+  label,
+  hideLabel,
+  action,
+}: ButtonProps) => {
   let svgSrc = '';
-  switch (props.label) {
+  switch (label) {
     case 'Edit':
       svgSrc = ActionEditIcon;
       break;
@@ -32,17 +36,16 @@ export const Button = (props: ButtonProps) => {
       overflow="visible"
       hoverStyle={{ fill: COLOR.grey }}
       onClick={() => {
-        props.action();
+        action();
       }}
       spacing={GAP.sm}
       padding={PADDING.xs}
       horizontalAlignItems="center"
       verticalAlignItems="center"
-      {...props}
     >
-      <Frame name="Icon" overflow="visible" width={SPACE.xxs} height={SPACE.xxs} {...props}>
+      <Frame name="Icon" overflow="visible" width={SPACE.xxs} height={SPACE.xxs}>
         <SVG
-          name={props.label}
+          name={label}
           x={{
             type: 'center',
             offset: PADDING.none,
@@ -66,9 +69,9 @@ export const Button = (props: ButtonProps) => {
         letterSpacing={FONT.letterSpacing.sm}
         fontWeight={FONT.weight.bold}
         textCase="upper"
-        hidden={props.hideLabel}
+        hidden={hideLabel}
       >
-        {props.label}
+        {label}
       </Text>
     </AutoLayout>
   );

--- a/widget-src/components/ChangeLogList.tsx
+++ b/widget-src/components/ChangeLogList.tsx
@@ -12,9 +12,15 @@ interface ChangeLogListProps {
   setUpdatedDate: (updatedDate: number) => void;
 }
 
-export const ChangeLogList = (props: ChangeLogListProps) => {
+export const ChangeLogList = ({
+  changeLogIds,
+  changeLogs,
+  // adminId,
+  deleteChange,
+  setUpdatedDate,
+}: ChangeLogListProps) => {
   useEffect(() => {
-    console.log('ChangeLogs', props.changeLogs.entries());
+    console.log('ChangeLogs', changeLogs.entries());
   });
 
   return (
@@ -28,12 +34,12 @@ export const ChangeLogList = (props: ChangeLogListProps) => {
         horizontal: PADDING.none,
       }}
     >
-      {props.changeLogIds.map((changeLogId, index) => {
-        const changeLog = props.changeLogs.get(changeLogId) as ChangeLog;
+      {changeLogIds.map((changeLogId, index) => {
+        const changeLog = changeLogs.get(changeLogId) as ChangeLog;
 
         function isEditable(): boolean {
           // if widget admin
-          // if (props.adminId === currentUser?.id) { return true; }
+          // if (adminId === currentUser?.id) { return true; }
           // if changeLog owner
           // if (changeLog?.user?.id === currentUser?.id) { return true; }
           return true;
@@ -44,10 +50,10 @@ export const ChangeLogList = (props: ChangeLogListProps) => {
             key={changeLogId}
             changeLogId={changeLogId}
             changeLog={changeLog}
-            isLastRow={index === props.changeLogIds.length - 1}
-            updateChange={changes => props.changeLogs.set(changeLogId, { ...changeLog, ...changes })}
-            deleteChange={() => props.deleteChange(changeLogId)}
-            setUpdatedDate={props.setUpdatedDate}
+            isLastRow={index === changeLogIds.length - 1}
+            updateChange={changes => changeLogs.set(changeLogId, { ...changeLog, ...changes })}
+            deleteChange={() => deleteChange(changeLogId)}
+            setUpdatedDate={setUpdatedDate}
             isEditable={isEditable()}
           />
         );

--- a/widget-src/components/ChangeLogRow.tsx
+++ b/widget-src/components/ChangeLogRow.tsx
@@ -18,18 +18,26 @@ interface ChangeLogRowProps {
   isEditable: boolean;
 }
 
-export const ChangeLogRow = (props: ChangeLogRowProps) => {
+export const ChangeLogRow = ({
+  changeLogId,
+  changeLog,
+  isLastRow,
+  updateChange,
+  deleteChange,
+  setUpdatedDate,
+  isEditable,
+}: ChangeLogRowProps) => {
   return (
     <AutoLayout
+      key={changeLogId}
       name="ChangeLogRow"
       fill={COLOR.white}
       overflow="visible"
       direction="vertical"
       width="fill-parent"
-      {...props}
     >
       <AutoLayout name="Wrapper" overflow="visible" spacing={GAP.md} width="fill-parent">
-        <User userName={props.changeLog.user?.name} userPhotoUrl={props.changeLog.user?.photoUrl} />
+        <User userName={changeLog.user?.name} userPhotoUrl={changeLog.user?.photoUrl} />
         <AutoLayout
           name="Change Content"
           overflow="visible"
@@ -65,18 +73,17 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
               fontWeight={FONT.weight.bold}
               textCase="upper"
             >
-              {props.changeLog.user?.name || ''}
+              {changeLog.user?.name || ''}
             </Text>
 
             <DateRange
-              editedDate={formatDate(props.changeLog.editedDate, 'date')}
-              editedTime={formatDate(props.changeLog.editedDate, 'time')}
-              date={formatDate(props.changeLog.createdDate, 'date')}
-              time={formatDate(props.changeLog.createdDate, 'time')}
-              editCount={props.changeLog.editCount}
-              edited={false}
+              editedDate={formatDate(changeLog.editedDate, 'date')}
+              editedTime={formatDate(changeLog.editedDate, 'time')}
+              date={formatDate(changeLog.createdDate, 'date')}
+              time={formatDate(changeLog.createdDate, 'time')}
+              editCount={changeLog.editCount}
             />
-            {props.isEditable && (
+            {isEditable && (
               <AutoLayout
                 name="Actions"
                 overflow="visible"
@@ -85,12 +92,12 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
                 horizontalAlignItems="end"
                 verticalAlignItems="center"
               >
-                <Button label="Delete" hideLabel={true} action={props.deleteChange} />
+                <Button label="Delete" hideLabel={true} action={deleteChange} />
               </AutoLayout>
             )}
           </AutoLayout>
           <AutoLayout name="Changes" overflow="visible" width="fill-parent">
-            {props.isEditable ? (
+            {isEditable ? (
               <Input
                 name="EditableChange"
                 fill={COLOR.black}
@@ -99,17 +106,17 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
                   fill: COLOR.white,
                 }}
                 onTextEditEnd={e => {
-                  if (e.characters !== props.changeLog.change) {
-                    props.updateChange({
+                  if (e.characters !== changeLog.change) {
+                    updateChange({
                       change: e.characters,
-                      editCount: props.changeLog.editCount + 1,
+                      editCount: changeLog.editCount + 1,
                       editedDate: Date.now(),
                     });
-                    props.setUpdatedDate(Date.now());
+                    setUpdatedDate(Date.now());
                   }
                 }}
                 placeholder="Your update..."
-                value={props.changeLog.change}
+                value={changeLog.change}
                 width="fill-parent"
                 lineHeight={FONT.lineHeight.lg}
                 fontFamily={FONT.family}
@@ -122,7 +129,7 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
                 fontFamily={FONT.family}
                 width={'fill-parent'}
               >
-                {props.changeLog.change || '...'}
+                {changeLog.change || '...'}
               </Text>
             )}
           </AutoLayout>
@@ -131,7 +138,7 @@ export const ChangeLogRow = (props: ChangeLogRowProps) => {
       </AutoLayout>
       <Rectangle
         name="Divider"
-        hidden={props.isLastRow}
+        hidden={isLastRow}
         stroke={COLOR.grey}
         width="fill-parent"
         height={SPACE.one}

--- a/widget-src/components/Footer.tsx
+++ b/widget-src/components/Footer.tsx
@@ -8,10 +8,10 @@ interface FooterProps {
   showBranding: boolean;
 }
 
-export const Footer = (props: FooterProps) => (
+export const Footer = ({ showBranding }: FooterProps) => (
   <AutoLayout name="Footer" overflow="visible" direction="vertical" spacing={GAP.lg} width="fill-parent">
     <Rectangle name="Divider" fill={COLOR.greyDark} strokeAlign="outside" width="fill-parent" height={SPACE.one} />
-    {props.showBranding && (
+    {showBranding && (
       <AutoLayout
         name="Logo"
         overflow="visible"

--- a/widget-src/components/Header.tsx
+++ b/widget-src/components/Header.tsx
@@ -21,7 +21,19 @@ interface HeaderProps {
   addChange: (changeId: string) => void;
 }
 
-export const Header = (props: HeaderProps) => {
+export const Header = ({
+  name,
+  description,
+  status,
+  createdDate,
+  setCreatedDate,
+  updatedDate,
+  setUpdatedDate,
+  version,
+  showVersion,
+  setVersion,
+  addChange,
+}: HeaderProps) => {
   const [nameText, setNameText] = useSyncedState('nameText', '');
   const [descriptionText, setDescriptionText] = useSyncedState('descriptionText', '');
 
@@ -29,30 +41,29 @@ export const Header = (props: HeaderProps) => {
     <AutoLayout name="Header" overflow="visible" direction="vertical" spacing={GAP.md} width="fill-parent">
       <AutoLayout name="Container" overflow="visible" direction="vertical" width="fill-parent">
         {/* STATUS */}
-        {props.status !== '0' && <Status status={props.status} />}
+        {status !== '0' && <Status status={status} />}
         {/* NAME */}
-        {props.name && (
-          <Name name={props.name} nameText={nameText} setNameText={setNameText} setUpdatedDate={props.setUpdatedDate} />
+        {name && (
+          <Name name={name} nameText={nameText} setNameText={setNameText} setUpdatedDate={setUpdatedDate} />
         )}
         {/* DESCRIPTION */}
-        {props.description && (
+        {description && (
           <Description
-            description={props.description}
+            description={description}
             descriptionText={descriptionText}
             setDescriptionText={setDescriptionText}
-            setUpdatedDate={props.setUpdatedDate}
+            setUpdatedDate={setUpdatedDate}
           />
         )}
         {/* META */}
         <Meta
-          createdDate={props.createdDate}
-          setCreatedDate={props.setCreatedDate}
-          updatedDate={props.updatedDate}
-          setUpdatedDate={props.setUpdatedDate}
-          version={props.version}
-          showVersion={props.showVersion}
-          setVersion={props.setVersion}
-          addChange={props.addChange}
+          createdDate={createdDate}
+          updatedDate={updatedDate}
+          setUpdatedDate={setUpdatedDate}
+          version={version}
+          showVersion={showVersion}
+          setVersion={setVersion}
+          addChange={addChange}
         />
       </AutoLayout>
       <Rectangle name="Divider" fill={COLOR.greyDark} strokeAlign="outside" width="fill-parent" height={SPACE.one} />

--- a/widget-src/components/WidgetContainer.tsx
+++ b/widget-src/components/WidgetContainer.tsx
@@ -7,7 +7,7 @@ interface WidgetContainerProps {
   children?: FigmaDeclarativeNode | FigmaDeclarativeNode[];
 }
 
-export const WidgetContainer = (props: WidgetContainerProps) => (
+export const WidgetContainer = ({ children }: WidgetContainerProps) => (
   <AutoLayout
     name="Widget"
     fill={COLOR.white}
@@ -21,6 +21,6 @@ export const WidgetContainer = (props: WidgetContainerProps) => (
     }}
     width={SPACE.xxl}
   >
-    {props.children}
+    {children}
   </AutoLayout>
 );

--- a/widget-src/components/header/Description.tsx
+++ b/widget-src/components/header/Description.tsx
@@ -10,7 +10,12 @@ interface DescriptionProps {
   setUpdatedDate: (updatedDate: number) => void;
 }
 
-export const Description = (props: DescriptionProps) => {
+export const Description = ({
+  description,
+  descriptionText,
+  setDescriptionText,
+  setUpdatedDate
+}: DescriptionProps) => {
   return (
     <AutoLayout
       name="DescriptionWrapper"
@@ -21,7 +26,7 @@ export const Description = (props: DescriptionProps) => {
         horizontal: PADDING.none,
       }}
       width="fill-parent"
-      hidden={!props.description}
+      hidden={!description}
     >
       <Input
         name="Description"
@@ -31,16 +36,16 @@ export const Description = (props: DescriptionProps) => {
           fill: COLOR.white,
         }}
         onTextEditEnd={e => {
-          props.setDescriptionText(e.characters);
-          props.setUpdatedDate(Date.now());
+          setDescriptionText(e.characters);
+          setUpdatedDate(Date.now());
         }}
         placeholder="Description..."
-        value={props.descriptionText}
+        value={descriptionText}
         width="fill-parent"
         lineHeight={FONT.lineHeight.xl}
         fontFamily="IBM Plex Sans"
         fontSize={FONT.size.lg}
-        hidden={!props.description}
+        hidden={!description}
       />
     </AutoLayout>
   );

--- a/widget-src/components/header/Meta.tsx
+++ b/widget-src/components/header/Meta.tsx
@@ -8,7 +8,6 @@ const { AutoLayout, SVG } = widget;
 
 interface MetaProps {
   createdDate: number;
-  setCreatedDate: (updatedDate: number) => void;
   updatedDate: number;
   setUpdatedDate: (updatedDate: number) => void;
   version: string;
@@ -17,7 +16,15 @@ interface MetaProps {
   addChange: (changeId: string) => void;
 }
 
-export const Meta = (props: MetaProps) => {
+export const Meta = ({
+  createdDate,
+  updatedDate,
+  setUpdatedDate,
+  version,
+  showVersion,
+  setVersion,
+  addChange
+}: MetaProps) => {
   return (
     <AutoLayout
       name="MetaWrapper"
@@ -33,16 +40,16 @@ export const Meta = (props: MetaProps) => {
       verticalAlignItems="center"
     >
       {/* LOGGING SINCE */}
-      <MetaValue label="Created" value={formatDate(props.createdDate, 'datetime')} />
+      <MetaValue label="Created" value={formatDate(createdDate, 'datetime')} />
       {/* LAST UPDATED */}
-      <MetaValue label="Updated" value={formatDate(props.updatedDate, 'datetime')} />
+      <MetaValue label="Updated" value={formatDate(updatedDate, 'datetime')} />
       {/* VERSION */}
-      {props.showVersion && (
+      {showVersion && (
         <MetaValue
           label="Version"
-          value={props.version}
-          setValue={props.setVersion}
-          setUpdatedDate={props.setUpdatedDate}
+          value={version}
+          setValue={setVersion}
+          setUpdatedDate={setUpdatedDate}
         />
       )}
       {/* NEW */}
@@ -61,7 +68,7 @@ export const Meta = (props: MetaProps) => {
             hoverStyle={{ fill: COLOR.grey }}
             onClick={() => {
               const changeId = randomId();
-              props.addChange(changeId);
+              addChange(changeId);
             }}
             overflow="visible"
             spacing={GAP.md}

--- a/widget-src/components/header/MetaValue.tsx
+++ b/widget-src/components/header/MetaValue.tsx
@@ -10,7 +10,12 @@ interface MetaValueProps {
   setUpdatedDate?: (updatedDate: number) => void;
 }
 
-export const MetaValue = (props: MetaValueProps) => {
+export const MetaValue = ({
+  label,
+  value,
+  setValue,
+  setUpdatedDate,
+}: MetaValueProps) => {
   return (
     <AutoLayout
       name="MetaValue"
@@ -32,9 +37,9 @@ export const MetaValue = (props: MetaValueProps) => {
         fontWeight={FONT.weight.bold}
         textCase="upper"
       >
-        {props.label}
+        {label}
       </Text>
-      {props.setValue && props.setUpdatedDate ? (
+      {setValue && setUpdatedDate ? (
         <Input
           name="EditableMetaValueValue"
           fill={COLOR.greyDark}
@@ -45,11 +50,11 @@ export const MetaValue = (props: MetaValueProps) => {
             fill: COLOR.white,
           }}
           onTextEditEnd={e => {
-            props.setValue ? props.setValue(e.characters) : null;
-            props.setUpdatedDate ? props.setUpdatedDate(Date.now()) : null;
+            setValue ? setValue(e.characters) : null;
+            setUpdatedDate ? setUpdatedDate(Date.now()) : null;
           }}
           placeholder="0.0.0"
-          value={props.value}
+          value={value}
           width={SPACE.md}
           inputBehavior="truncate"
           truncate={0}
@@ -64,7 +69,7 @@ export const MetaValue = (props: MetaValueProps) => {
           letterSpacing={FONT.letterSpacing.sm}
           width={'hug-contents'}
         >
-          {props.value}
+          {value}
         </Text>
       )}
     </AutoLayout>

--- a/widget-src/components/header/Name.tsx
+++ b/widget-src/components/header/Name.tsx
@@ -10,9 +10,14 @@ interface NameProps {
   setUpdatedDate: (updatedDate: number) => void;
 }
 
-export const Name = (props: NameProps) => {
+export const Name = ({
+  name,
+  nameText,
+  setNameText,
+  setUpdatedDate,
+}: NameProps) => {
   return (
-    <AutoLayout name="NameWrapper" overflow="visible" direction="vertical" width="fill-parent" hidden={!props.name}>
+    <AutoLayout name="NameWrapper" overflow="visible" direction="vertical" width="fill-parent" hidden={!name}>
       <Input
         name="Name"
         fill={COLOR.black}
@@ -25,12 +30,12 @@ export const Name = (props: NameProps) => {
           fill: COLOR.white,
         }}
         onTextEditEnd={e => {
-          props.setNameText(e.characters);
-          props.setUpdatedDate(Date.now());
+          setNameText(e.characters);
+          setUpdatedDate(Date.now());
         }}
         placeholder="Name..."
-        value={props.nameText}
-        hidden={!props.name}
+        value={nameText}
+        hidden={!name}
       />
     </AutoLayout>
   );

--- a/widget-src/components/header/Status.tsx
+++ b/widget-src/components/header/Status.tsx
@@ -7,10 +7,10 @@ interface StatusProps {
   status: string;
 }
 
-export const Status = (props: StatusProps) => {
+export const Status = ({ status }: StatusProps) => {
   let statusEmoji = '';
   let statusLabel = '';
-  switch (props.status) {
+  switch (status) {
     case '1':
       statusEmoji = '🙋‍♀️';
       statusLabel = 'Proposed';

--- a/widget-src/components/log/DateRange.tsx
+++ b/widget-src/components/log/DateRange.tsx
@@ -9,12 +9,17 @@ interface DateRangeProps {
   date: string;
   time: string;
   editCount: number;
-  edited?: boolean;
 }
 
-export const DateRange = (props: DateRangeProps) => {
+export const DateRange = ({
+  editedDate,
+  editedTime,
+  date,
+  time,
+  editCount,
+}: DateRangeProps) => {
   return (
-    <AutoLayout name="Log Date" overflow="visible" spacing={GAP.md} verticalAlignItems="center" {...props}>
+    <AutoLayout name="Log Date" overflow="visible" spacing={GAP.md} verticalAlignItems="center">
       <Text
         name="Created"
         fill={COLOR.black}
@@ -24,12 +29,12 @@ export const DateRange = (props: DateRangeProps) => {
         letterSpacing={FONT.letterSpacing.sm}
         fontWeight={FONT.weight.bold}
         textCase="upper"
-        hidden={props.date === undefined}
+        hidden={date === undefined}
       >
-        {`${props.date} @ ${props.time}`}
+        {`${date} @ ${time}`}
       </Text>
 
-      {props.editCount >= 2 && (
+      {editCount >= 2 && (
         <Text
           name="Edited"
           fill={COLOR.greyDark}
@@ -38,7 +43,7 @@ export const DateRange = (props: DateRangeProps) => {
           fontSize={FONT.size.xs}
           letterSpacing={FONT.letterSpacing.sm}
         >
-          {`EDITED ${props.editedDate} @ ${props.editedTime}`}
+          {`EDITED ${editedDate} @ ${editedTime}`}
         </Text>
       )}
     </AutoLayout>

--- a/widget-src/components/log/Type.tsx
+++ b/widget-src/components/log/Type.tsx
@@ -7,10 +7,10 @@ interface TypeProps {
   type: 'Added' | 'Breaking' | 'Changed' | 'Deprecated' | 'Fixed' | 'Other' | 'Removed';
 }
 
-export const Type = (props: TypeProps) => {
+export const Type = ({ type }: TypeProps) => {
   let txColor = COLOR.white;
   let bgColor = COLOR.black;
-  switch (props.type) {
+  switch (type) {
     case 'Added':
       bgColor = COLOR.green;
       break;
@@ -47,7 +47,6 @@ export const Type = (props: TypeProps) => {
       }}
       horizontalAlignItems="center"
       verticalAlignItems="center"
-      {...props}
     >
       <Text
         name="Type"
@@ -61,7 +60,7 @@ export const Type = (props: TypeProps) => {
         fontWeight={FONT.weight.bold}
         textCase="upper"
       >
-        {props.type}
+        {type}
       </Text>
     </AutoLayout>
   );

--- a/widget-src/components/log/User.tsx
+++ b/widget-src/components/log/User.tsx
@@ -8,7 +8,7 @@ interface UserProps {
   userPhotoUrl: string | null | undefined;
 }
 
-export const User = (props: UserProps) => {
+export const User = ({ userName, userPhotoUrl }: UserProps) => {
   return (
     <AutoLayout
       name="User"
@@ -21,16 +21,15 @@ export const User = (props: UserProps) => {
       }}
       height="fill-parent"
       horizontalAlignItems="center"
-      {...props}
     >
-      <AutoLayout name="Avatar" overflow="visible" spacing={GAP.md} verticalAlignItems="center" {...props}>
-        {props.userPhotoUrl ? (
+      <AutoLayout name="Avatar" overflow="visible" spacing={GAP.md} verticalAlignItems="center">
+        {userPhotoUrl ? (
           <Image
             name="UserImage"
             cornerRadius={RADIUS.lg}
             width={SPACE.sm}
             height={SPACE.sm}
-            src={props.userPhotoUrl}
+            src={userPhotoUrl}
           />
         ) : (
           <Rectangle name="Placeholder" fill={COLOR.grey} cornerRadius={RADIUS.lg} width={SPACE.sm} height={SPACE.sm} />
@@ -45,7 +44,7 @@ export const User = (props: UserProps) => {
           letterSpacing={FONT.letterSpacing.sm}
           textCase="upper"
         >
-          {props.userName || 'Unknown User'}
+          {userName || 'Unknown User'}
         </Text>
       </AutoLayout>
       <Rectangle

--- a/widget-src/types/StatusDisplayNames.ts
+++ b/widget-src/types/StatusDisplayNames.ts
@@ -1,5 +1,5 @@
 export const STATUS_TYPE_DISPLAY_NAMES: { [key in StatusType]: string } = {
-  none: 'Set Status...',
+  none: 'Status...',
   proposed: '🙋‍♀️ Proposed',
   draft: '🚧 Draft',
   beta: '🧑‍🚀 Beta',


### PR DESCRIPTION
- Converted all components to spreading property names instead of the `props` variable
  - converted all property usage to property name only - removed the `prop.`
- Removed unused component properties