### PR TITLE
Multiple Links Bug Fix

### DIFF
--- a/widget-src/components/log/DateRangeForm.tsx
+++ b/widget-src/components/log/DateRangeForm.tsx
@@ -127,7 +127,7 @@ export const DateRangeForm = ({ changeLog, timestamp, updateChangeState }: DateR
             stroke: !!changeLog.state?.updates?.createdDateTmp?.date.er ? COLOR.red : COLOR.grey,
             strokeWidth: SPACE.one,
             cornerRadius: RADIUS.xs,
-            padding: { horizontal: PADDING.xs, vertical: PADDING.xs },
+            padding: { horizontal: PADDING.xxs, vertical: PADDING.xxs },
           }}
           placeholder={changeLog.state?.updates?.createdDateTmp?.date.val || displayDate(timestamp, 'date')}
           value={changeLog.state?.updates?.createdDateTmp?.date.val || displayDate(timestamp, 'date')}
@@ -219,7 +219,7 @@ export const DateRangeForm = ({ changeLog, timestamp, updateChangeState }: DateR
             stroke: !!changeLog.state?.updates?.createdDateTmp?.time.er ? COLOR.red : COLOR.grey,
             strokeWidth: SPACE.one,
             cornerRadius: RADIUS.xs,
-            padding: { horizontal: PADDING.xs, vertical: PADDING.xs },
+            padding: { horizontal: PADDING.xxs, vertical: PADDING.xxs },
           }}
           placeholder={changeLog.state?.updates?.createdDateTmp?.time.val || displayDate(timestamp, 'time')}
           value={changeLog.state?.updates?.createdDateTmp?.time.val || displayDate(timestamp, 'time')}

--- a/widget-src/components/log/LinkForm.tsx
+++ b/widget-src/components/log/LinkForm.tsx
@@ -221,8 +221,8 @@ export const LinkForm = ({ changeLog, updateChangeState, setUpdatedDate }: LinkF
                 showLinkForm: false,
                 updates: {
                   ...changeLog.state?.updates,
-                  links: !!changeLog.links
-                    ? [...changeLog.links, { ...changeLog.state?.updates?.link, key: linkKey }]
+                  links: changeLog.state?.updates?.links
+                    ? [...changeLog.state.updates.links, { ...changeLog.state?.updates?.link, key: linkKey }]
                     : [{ ...changeLog.state?.updates?.link, key: linkKey }],
                   link: { label: '', url: '', key: '', icon: '' },
                   linkFormError: {


### PR DESCRIPTION
### Description

Previously, adding a second link to the list would overwrite the previous link. This forced a user to save the log before adding a second link.

I changed `!!changeLog.links` to `changeLog.state?.updates?.links` to reference the existing links array

I updated array manipulation logic to ensure that links are correctly appended

Fixes # (issue)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I tested in Figma locally. No changes were made to the data structure.